### PR TITLE
`use_alternative_class` rule

### DIFF
--- a/lib/src/analyzer/rules/rules.dart
+++ b/lib/src/analyzer/rules/rules.dart
@@ -1,13 +1,16 @@
 import '../rule/rule.dart';
 import 'no_bare_strings/no_bare_strings.dart';
 import 'no_material_cupertino_imports/no_material_cupertino_imports.dart';
+import 'use_alternative_class/use_alternative_class.dart';
 
 export 'no_bare_strings/no_bare_strings.dart';
 export 'no_material_cupertino_imports/no_material_cupertino_imports.dart';
+export 'use_alternative_class/use_alternative_class.dart';
 
 /// List of all custom analyzer rules.
 final rules = <Rule>[
   NoMaterialCupertinoImportsRule(),
   NoBareStrings(),
+  UseAlternativeClassRule.empty(),
   // Add more rules here
 ];

--- a/lib/src/analyzer/rules/use_alternative_class/use_alternative_class.dart
+++ b/lib/src/analyzer/rules/use_alternative_class/use_alternative_class.dart
@@ -1,0 +1,46 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+
+import '../../options/options.dart';
+import '../../rule/rule.dart';
+import 'use_alternative_class_visitor.dart';
+
+class UseAlternativeClassRule extends Rule {
+  UseAlternativeClassRule({
+    required String this.targetClass,
+    required String this.alternativeClass,
+  });
+
+  UseAlternativeClassRule.empty()
+      : targetClass = null,
+        alternativeClass = null;
+
+  final String? targetClass;
+  final String? alternativeClass;
+
+  @override
+  String get id => 'use_alternative_class';
+
+  @override
+  String get message {
+    assert(targetClass != null);
+    return 'Avoid using $targetClass.';
+  }
+
+  @override
+  String? get correction {
+    assert(targetClass != null);
+    assert(alternativeClass != null);
+    return 'Use $alternativeClass instead of $targetClass.';
+  }
+
+  @override
+  AnalysisErrorSeverity get severity => AnalysisErrorSeverity.WARNING;
+
+  @override
+  RuleVisitor getVisitor(
+    ResolvedUnitResult result,
+    RuleConfig config,
+  ) =>
+      UseAlternativeClassVisitor(rule: this, result: result, config: config);
+}

--- a/lib/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor.dart
+++ b/lib/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer_plugin/protocol/protocol_generated.dart';
 
@@ -13,19 +11,22 @@ class UseAlternativeClassVisitor extends RecursiveRuleVisitor {
     required super.result,
     required super.config,
   }) {
-    final allowedClasses = config.options[allowedClassesKey] as List<Object>?;
+    _alternatives = {};
+    final alternatives = config.options[alternativeKey];
 
-    _alternatives =
-        (config.options[alternativeKey] as UnmodifiableMapView<String, Object?>?)
-                ?.entries.where((e) => allowedClasses == null || !allowedClasses.contains(e.key))
-                .map((e) => MapEntry(e.key, e.value! as String)).toList() ?? [];
+    if (alternatives is Map<String, Object?>) {
+      for (final alternative in alternatives.entries) {
+        final replacement = alternative.value;
+        if (replacement is String) {
+          _alternatives[alternative.key] = replacement;
+        }
+      }
+    }
   }
 
   static const alternativeKey = 'alternatives';
-  static const allowedClassesKey = 'allowed_classes';
 
-
-  late final List<MapEntry<String, String>> _alternatives;
+  late final Map<String, String> _alternatives;
 
   @override
   void visitConstructorName(ConstructorName node) {
@@ -39,7 +40,7 @@ class UseAlternativeClassVisitor extends RecursiveRuleVisitor {
       className = name.substring(0, name.length - (constructorName.length + 1));
     }
 
-    for (final entry in _alternatives) {
+    for (final entry in _alternatives.entries) {
       if (className == entry.key) {
         errors.add(
           AnalysisErrorFixes(

--- a/lib/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor.dart
+++ b/lib/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor.dart
@@ -1,0 +1,61 @@
+import 'dart:collection';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer_plugin/protocol/protocol_generated.dart';
+
+import '../../rule/rule_visitor.dart';
+import '../../rule/utils.dart';
+import 'use_alternative_class.dart';
+
+class UseAlternativeClassVisitor extends RecursiveRuleVisitor {
+  UseAlternativeClassVisitor({
+    required super.rule,
+    required super.result,
+    required super.config,
+  }) {
+    final allowedClasses = config.options[allowedClassesKey] as List<Object>?;
+
+    _alternatives =
+        (config.options[alternativeKey] as UnmodifiableMapView<String, Object?>?)
+                ?.entries.where((e) => allowedClasses == null || !allowedClasses.contains(e.key))
+                .map((e) => MapEntry(e.key, e.value! as String)).toList() ?? [];
+  }
+
+  static const alternativeKey = 'alternatives';
+  static const allowedClassesKey = 'allowed_classes';
+
+
+  late final List<MapEntry<String, String>> _alternatives;
+
+  @override
+  void visitConstructorName(ConstructorName node) {
+    final constructorName = node.name;
+    late final String className;
+
+    if (constructorName == null) {
+      className = node.toString();
+    } else {
+      final name = node.toString();
+      className = name.substring(0, name.length - (constructorName.length + 1));
+    }
+
+    for (final entry in _alternatives) {
+      if (className == entry.key) {
+        errors.add(
+          AnalysisErrorFixes(
+            generateError(
+              rule: UseAlternativeClassRule(
+                targetClass: entry.key,
+                alternativeClass: entry.value,
+              ),
+              result: result,
+              node: node,
+              hasFix: false,
+              documentationUrl: documentationUrl,
+            ),
+          ),
+        );
+      }
+    }
+  }
+}

--- a/test/src/analyzer/rules/use_alternative_class/use_alternative_class_test.dart
+++ b/test/src/analyzer/rules/use_alternative_class/use_alternative_class_test.dart
@@ -1,0 +1,54 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:dart_custom_analyzer_plugin/src/analyzer/options/options.dart';
+import 'package:dart_custom_analyzer_plugin/src/analyzer/rule/rule_visitor.dart';
+import 'package:dart_custom_analyzer_plugin/src/analyzer/rules/use_alternative_class/use_alternative_class.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:recase/recase.dart';
+import 'package:test/test.dart';
+
+class MockResult extends Mock implements ResolvedUnitResult {}
+
+void main() {
+  group('UseAlternativeClassRule', () {
+    test('instantiates with correct values', () {
+      final rule = UseAlternativeClassRule(
+        targetClass: 'TargetClass',
+        alternativeClass: 'AlternativeClass',
+      );
+
+      // Rule id should be snake_case version of the rule's class name,
+      // without the `_rule` suffix.
+      expect(
+        rule.id,
+        rule.runtimeType.toString().replaceAll('Rule', '').snakeCase,
+      );
+
+      expect(
+        rule.message,
+        isA<String>().having((s) => s.length, 'length', greaterThan(0)),
+      );
+
+      expect(
+        rule.correction,
+        isA<String?>(),
+      );
+
+      expect(
+        rule.severity,
+        isA<AnalysisErrorSeverity>(),
+      );
+
+      final result = MockResult();
+      final config = RuleConfig();
+
+      expect(
+        rule.getVisitor(result, config),
+        isA<RuleVisitor>()
+            .having((visitor) => visitor.rule, 'rule', same(rule))
+            .having((visitor) => visitor.result, 'result', same(result))
+            .having((visitor) => visitor.config, 'config', same(config)),
+      );
+    });
+  });
+}

--- a/test/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor_test.dart
+++ b/test/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor_test.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:dart_custom_analyzer_plugin/src/analyzer/options/options.dart';
@@ -78,20 +76,21 @@ void main() {
       test('does not add error for class in allowed list ', () {
         final constructorName = _DisallowedMockConstructorName();
         final config = RuleConfig()
-          ..options = <String, Object>{
-            UseAlternativeClassVisitor.alternativeKey: 
-              UnmodifiableMapView(<String, String>{disallowedClassName: 'AlternativeClass'}),
-            UseAlternativeClassVisitor.allowedClassesKey: [disallowedClassName],
+          ..options = {
+            UseAlternativeClassVisitor.alternativeKey: {
+              disallowedClassName: 'AlternativeClass'
+            },
           };
 
         when(() => constructorName.name).thenReturn(null);
         generateError = testGenerateError(error);
 
-        final visitor = createVisitor(config)..visitConstructorName(constructorName);
+        final visitor = createVisitor(config)
+          ..visitConstructorName(constructorName);
 
         expect(visitor.errors, isEmpty);
       });
-      
+
       test('adds error for disallowed class', () {
         final constructorName = _DisallowedMockConstructorName();
 
@@ -121,8 +120,10 @@ void main() {
 }
 
 UseAlternativeClassVisitor createVisitor([RuleConfig? config]) {
-  config ??= RuleConfig()..options[UseAlternativeClassVisitor.alternativeKey] =
-    UnmodifiableMapView(<String, String>{disallowedClassName: 'AlternativeClass'});
+  config ??= RuleConfig()
+    ..options[UseAlternativeClassVisitor.alternativeKey] = {
+      disallowedClassName: 'AlternativeClass'
+    };
   final rule = MockRule();
   final result = MockResult();
 

--- a/test/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor_test.dart
+++ b/test/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor_test.dart
@@ -1,0 +1,134 @@
+import 'dart:collection';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:dart_custom_analyzer_plugin/src/analyzer/options/options.dart';
+import 'package:dart_custom_analyzer_plugin/src/analyzer/rule/rule.dart';
+import 'package:dart_custom_analyzer_plugin/src/analyzer/rules/use_alternative_class/use_alternative_class_visitor.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_utils.dart';
+
+const mockNamedConstructor = 'create';
+
+class _AllowedMockConstructorName extends Mock implements ConstructorName {}
+
+class _DisallowedMockConstructorName extends Mock implements ConstructorName {
+  _DisallowedMockConstructorName();
+  _DisallowedMockConstructorName.create() : _constructor = mockNamedConstructor;
+
+  String? _constructor;
+
+  @override
+  String toString() {
+    if (_constructor == null) {
+      return super.toString();
+    }
+    return '${super.toString()}.$_constructor';
+  }
+}
+
+const allowedMockClassName = '_AllowedMockConstructorName';
+const disallowedClassName = '_DisallowedMockConstructorName';
+
+void main() {
+  group('UseAlternativeClassVisitor', () {
+    test(
+      'instantiates with correct values when config is empty',
+      () {
+        final rule = MockRule();
+        final result = MockResult();
+        final config = RuleConfig();
+
+        final visitor = UseAlternativeClassVisitor(
+          rule: rule,
+          result: result,
+          config: config,
+        );
+
+        expect(visitor.rule, same(rule));
+        expect(visitor.result, same(result));
+        expect(visitor.config, same(config));
+      },
+    );
+
+    group('visitConstructorName', () {
+      final error = AnalysisError(
+        AnalysisErrorSeverity.ERROR,
+        AnalysisErrorType.HINT,
+        Location('file.dart', 0, 0, 0, 0),
+        'error message',
+        'code',
+      );
+
+      tearDownAll(() => generateError = defaultGenerateError);
+
+      test('does not add error for allowed class', () {
+        final constructorName = _AllowedMockConstructorName();
+
+        when(() => constructorName.name).thenReturn(null);
+        generateError = testGenerateError(error);
+
+        final visitor = createVisitor()..visitConstructorName(constructorName);
+
+        expect(visitor.errors, isEmpty);
+      });
+
+      test('does not add error for class in allowed list ', () {
+        final constructorName = _DisallowedMockConstructorName();
+        final config = RuleConfig()
+          ..options = <String, Object>{
+            UseAlternativeClassVisitor.alternativeKey: 
+              UnmodifiableMapView(<String, String>{disallowedClassName: 'AlternativeClass'}),
+            UseAlternativeClassVisitor.allowedClassesKey: [disallowedClassName],
+          };
+
+        when(() => constructorName.name).thenReturn(null);
+        generateError = testGenerateError(error);
+
+        final visitor = createVisitor(config)..visitConstructorName(constructorName);
+
+        expect(visitor.errors, isEmpty);
+      });
+      
+      test('adds error for disallowed class', () {
+        final constructorName = _DisallowedMockConstructorName();
+
+        when(() => constructorName.name).thenReturn(null);
+        generateError = testGenerateError(error);
+
+        final visitor = createVisitor()..visitConstructorName(constructorName);
+
+        expect(visitor.errors.single.error, same(error));
+      });
+
+      test('adds error for disallowed class with constructor', () {
+        final constructorName = _DisallowedMockConstructorName.create();
+        final simpleId = MockSimpleIdentifier();
+
+        when(() => simpleId.name).thenReturn(mockNamedConstructor);
+        when(() => simpleId.length).thenReturn(mockNamedConstructor.length);
+        when(() => constructorName.name).thenReturn(simpleId);
+
+        generateError = testGenerateError(error);
+
+        final visitor = createVisitor()..visitConstructorName(constructorName);
+        expect(visitor.errors.single.error, same(error));
+      });
+    });
+  });
+}
+
+UseAlternativeClassVisitor createVisitor([RuleConfig? config]) {
+  config ??= RuleConfig()..options[UseAlternativeClassVisitor.alternativeKey] =
+    UnmodifiableMapView(<String, String>{disallowedClassName: 'AlternativeClass'});
+  final rule = MockRule();
+  final result = MockResult();
+
+  return UseAlternativeClassVisitor(
+    rule: rule,
+    result: result,
+    config: config,
+  );
+}


### PR DESCRIPTION
provide the new `use_alternative_class` rule. we will use this rule when we need to encourage the use of another Class instead of the standard Class.

for example, set up something like this..

```
custom_linter:
  rules:
    - use_alternative_class:
        alternatives:
          'Container': 'CustomContainer'
```